### PR TITLE
DD-1946: upgrade parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans</groupId>
         <artifactId>dd-parent</artifactId>
-        <version>1.9.0</version>
+        <version>1.10.0</version>
         <relativePath />
     </parent>
     <artifactId>dans-bagpack-lib</artifactId>
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-bagit-lib</artifactId>
-            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -58,7 +57,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
-            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>
@@ -88,6 +86,8 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>apache-jena-libs</artifactId>
+            <version>4.10.0</version>
+            <!-- see TODO on JsonLDWriteContext in OaiSerializer.java, it blocks upgrade to Jena 5 -->
             <type>pom</type>
         </dependency>
 


### PR DESCRIPTION
* Parent upgrade
* Jena v5 would require JSONLD10 -> JSONLD11 in the following code snippet, so downgraded locally

https://github.com/DANS-KNAW/dans-bagpack-lib/blob/d75a377db085ef3301f70ce2ae424567a99c39ea/src/main/java/nl/knaw/dans/lib/bagpack/oaiore/OaiOreSerializer.java#L100-L106